### PR TITLE
fix: Install pip in upgrade script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	# Make sure to compile files after any other files they include!
 	$(PIP_COMPILE) --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in
 	$(PIP_COMPILE) -o requirements/pip-tools.txt requirements/pip-tools.in
+	pip install -r requirements/pip.txt
 	pip install -r requirements/pip-tools.txt
 	$(PIP_COMPILE) -o requirements/base.txt requirements/base.in
 	$(PIP_COMPILE) -o requirements/test.txt requirements/test.in

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ requirements:   ## install development environment requirements
 	pip install -qr requirements/dev.txt --exists-action w
 
 tests: ## Run tests and generate coverage report
-    pytest
+	pytest
 
 quality: ## check coding style with pycodestyle and pylint
 	pylint loncapa verifiers eia

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,17 +4,17 @@
 #
 #    make upgrade
 #
-certifi==2021.10.8
+certifi==2022.6.15
     # via requests
-charset-normalizer==2.0.12
+charset-normalizer==2.1.0
     # via requests
 codecov==2.1.12
     # via -r requirements/ci.in
-coverage==6.3.3
+coverage==6.4.3
     # via codecov
-distlib==0.3.4
+distlib==0.3.5
     # via virtualenv
-filelock==3.7.0
+filelock==3.8.0
     # via
     #   tox
     #   virtualenv
@@ -30,17 +30,15 @@ py==1.11.0
     # via tox
 pyparsing==3.0.9
     # via packaging
-requests==2.27.1
+requests==2.28.1
     # via codecov
 six==1.16.0
-    # via
-    #   tox
-    #   virtualenv
+    # via tox
 toml==0.10.2
     # via tox
-tox==3.25.0
+tox==3.25.1
     # via -r requirements/ci.in
-urllib3==1.26.9
+urllib3==1.26.11
     # via requests
-virtualenv==20.14.1
+virtualenv==20.16.3
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,27 +4,31 @@
 #
 #    make upgrade
 #
-astroid==2.11.5
+astroid==2.11.7
     # via
     #   -r requirements/quality.txt
     #   pylint
     #   pylint-celery
-attrs==21.4.0
+attrs==22.1.0
     # via
     #   -r requirements/quality.txt
     #   pytest
-bleach==5.0.0
+bleach==5.0.1
     # via
     #   -r requirements/quality.txt
     #   readme-renderer
-certifi==2021.10.8
+build==0.8.0
+    # via
+    #   -r requirements/pip-tools.txt
+    #   pip-tools
+certifi==2022.6.15
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
-chardet==4.0.0
+chardet==5.0.0
     # via diff-cover
-charset-normalizer==2.0.12
+charset-normalizer==2.1.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -51,29 +55,29 @@ commonmark==0.9.1
     # via
     #   -r requirements/quality.txt
     #   rich
-coverage[toml]==6.3.3
+coverage[toml]==6.4.3
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   codecov
     #   pytest-cov
-diff-cover==6.5.0
+diff-cover==6.5.1
     # via -r requirements/dev.in
-dill==0.3.4
+dill==0.3.5.1
     # via
     #   -r requirements/quality.txt
     #   pylint
-distlib==0.3.4
+distlib==0.3.5
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-docutils==0.18.1
+docutils==0.19
     # via
     #   -r requirements/quality.txt
     #   readme-renderer
-edx-lint==5.2.2
+edx-lint==5.2.4
     # via -r requirements/quality.txt
-filelock==3.7.0
+filelock==3.8.0
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -83,7 +87,7 @@ idna==3.3
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
-importlib-metadata==4.11.3
+importlib-metadata==4.12.0
     # via
     #   -r requirements/quality.txt
     #   keyring
@@ -101,7 +105,7 @@ jinja2==3.1.2
     #   -r requirements/quality.txt
     #   code-annotations
     #   diff-cover
-keyring==23.5.0
+keyring==23.8.2
     # via
     #   -r requirements/quality.txt
     #   twine
@@ -120,20 +124,22 @@ mccabe==0.7.0
 packaging==21.3
     # via
     #   -r requirements/ci.txt
+    #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
+    #   build
     #   pytest
     #   tox
-pbr==5.9.0
+pbr==5.10.0
     # via
     #   -r requirements/quality.txt
     #   stevedore
-pep517==0.12.0
+pep517==0.13.0
     # via
     #   -r requirements/pip-tools.txt
-    #   pip-tools
-pip-tools==6.6.1
+    #   build
+pip-tools==6.8.0
     # via -r requirements/pip-tools.txt
-pkginfo==1.8.2
+pkginfo==1.8.3
     # via
     #   -r requirements/quality.txt
     #   twine
@@ -156,7 +162,7 @@ py==1.11.0
     #   -r requirements/quality.txt
     #   pytest
     #   tox
-pycodestyle==2.8.0
+pycodestyle==2.9.1
     # via -r requirements/quality.txt
 pydocstyle==6.1.1
     # via -r requirements/quality.txt
@@ -166,7 +172,7 @@ pygments==2.12.0
     #   diff-cover
     #   readme-renderer
     #   rich
-pylint==2.13.9
+pylint==2.14.5
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -189,6 +195,7 @@ pylint-plugin-utils==0.7
 pyparsing==3.0.9
     # via
     #   -r requirements/ci.txt
+    #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
     #   packaging
 pytest==7.1.2
@@ -205,11 +212,11 @@ pyyaml==6.0
     # via
     #   -r requirements/quality.txt
     #   code-annotations
-readme-renderer==35.0
+readme-renderer==36.0
     # via
     #   -r requirements/quality.txt
     #   twine
-requests==2.27.1
+requests==2.28.1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -224,7 +231,7 @@ rfc3986==2.0.0
     # via
     #   -r requirements/quality.txt
     #   twine
-rich==12.4.1
+rich==12.5.1
     # via
     #   -r requirements/quality.txt
     #   twine
@@ -235,12 +242,11 @@ six==1.16.0
     #   bleach
     #   edx-lint
     #   tox
-    #   virtualenv
 snowballstemmer==2.2.0
     # via
     #   -r requirements/quality.txt
     #   pydocstyle
-stevedore==3.5.0
+stevedore==4.0.0
     # via
     #   -r requirements/quality.txt
     #   code-annotations
@@ -256,31 +262,36 @@ tomli==2.0.1
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
+    #   build
     #   coverage
     #   pep517
     #   pylint
     #   pytest
-tox==3.25.0
+tomlkit==0.11.3
+    # via
+    #   -r requirements/quality.txt
+    #   pylint
+tox==3.25.1
     # via
     #   -r requirements/ci.txt
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/dev.in
-twine==4.0.0
+twine==4.0.1
     # via -r requirements/quality.txt
-typing-extensions==4.2.0
+typing-extensions==4.3.0
     # via
     #   -r requirements/quality.txt
     #   astroid
     #   pylint
     #   rich
-urllib3==1.26.9
+urllib3==1.26.11
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
     #   twine
-virtualenv==20.14.1
+virtualenv==20.16.3
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -296,7 +307,7 @@ wrapt==1.14.1
     # via
     #   -r requirements/quality.txt
     #   astroid
-zipp==3.8.0
+zipp==3.8.1
     # via
     #   -r requirements/quality.txt
     #   importlib-metadata

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -6,29 +6,29 @@
 #
 alabaster==0.7.12
     # via sphinx
-attrs==21.4.0
+attrs==22.1.0
     # via
     #   -r requirements/test.txt
     #   pytest
-babel==2.10.1
+babel==2.10.3
     # via sphinx
-bleach==5.0.0
+bleach==5.0.1
     # via readme-renderer
-build==0.7.0
+build==0.8.0
     # via -r requirements/doc.in
-certifi==2021.10.8
+certifi==2022.6.15
     # via requests
-charset-normalizer==2.0.12
+charset-normalizer==2.1.0
     # via requests
 commonmark==0.9.1
     # via rich
-coverage[toml]==6.3.3
+coverage[toml]==6.4.3
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-doc8==0.11.1
+doc8==1.0.0
     # via -r requirements/doc.in
-docutils==0.17.1
+docutils==0.19
     # via
     #   doc8
     #   readme-renderer
@@ -38,9 +38,9 @@ edx-sphinx-theme==3.0.0
     # via -r requirements/doc.in
 idna==3.3
     # via requests
-imagesize==1.3.0
+imagesize==1.4.1
     # via sphinx
-importlib-metadata==4.11.3
+importlib-metadata==4.12.0
     # via
     #   keyring
     #   sphinx
@@ -51,7 +51,7 @@ iniconfig==1.1.1
     #   pytest
 jinja2==3.1.2
     # via sphinx
-keyring==23.5.0
+keyring==23.8.2
     # via twine
 markupsafe==2.1.1
     # via jinja2
@@ -63,9 +63,9 @@ packaging==21.3
     #   sphinx
 pbr==5.9.0
     # via stevedore
-pep517==0.12.0
+pep517==0.13.0
     # via build
-pkginfo==1.8.2
+pkginfo==1.8.3
     # via twine
 pluggy==1.0.0
     # via
@@ -93,9 +93,9 @@ pytest-cov==3.0.0
     # via -r requirements/test.txt
 pytz==2022.1
     # via babel
-readme-renderer==35.0
+readme-renderer==36.0
     # via twine
-requests==2.27.1
+requests==2.28.1
     # via
     #   requests-toolbelt
     #   sphinx
@@ -106,7 +106,7 @@ restructuredtext-lint==1.4.0
     # via doc8
 rfc3986==2.0.0
     # via twine
-rich==12.4.1
+rich==12.5.1
     # via twine
 six==1.16.0
     # via
@@ -115,7 +115,7 @@ six==1.16.0
     #   edx-sphinx-theme
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==4.5.0
+sphinx==5.1.1
     # via
     #   -r requirements/doc.in
     #   edx-sphinx-theme
@@ -131,24 +131,25 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-stevedore==3.5.0
+stevedore==4.0.0
     # via doc8
 tomli==2.0.1
     # via
     #   -r requirements/test.txt
     #   build
     #   coverage
+    #   doc8
     #   pep517
     #   pytest
-twine==4.0.0
+twine==4.0.1
     # via -r requirements/doc.in
-typing-extensions==4.2.0
+typing-extensions==4.3.0
     # via rich
-urllib3==1.26.9
+urllib3==1.26.11
     # via
     #   requests
     #   twine
 webencodings==0.5.1
     # via bleach
-zipp==3.8.0
+zipp==3.8.1
     # via importlib-metadata

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,14 +4,22 @@
 #
 #    make upgrade
 #
+build==0.8.0
+    # via pip-tools
 click==8.1.3
     # via pip-tools
-pep517==0.12.0
-    # via pip-tools
-pip-tools==6.6.1
+packaging==21.3
+    # via build
+pep517==0.13.0
+    # via build
+pip-tools==6.8.0
     # via -r requirements/pip-tools.in
+pyparsing==3.0.9
+    # via packaging
 tomli==2.0.1
-    # via pep517
+    # via
+    #   build
+    #   pep517
 wheel==0.37.1
     # via pip-tools
 

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -1,4 +1,5 @@
 # Core dependencies for installing other packages
+-c constraints.txt
 
 pip
 setuptools

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,9 @@ wheel==0.37.1
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==22.1
+pip==22.2.2
     # via -r requirements/pip.in
-setuptools==62.3.1
-    # via -r requirements/pip.in
+setuptools==59.8.0
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,19 +4,19 @@
 #
 #    make upgrade
 #
-astroid==2.11.5
+astroid==2.11.7
     # via
     #   pylint
     #   pylint-celery
-attrs==21.4.0
+attrs==22.1.0
     # via
     #   -r requirements/test.txt
     #   pytest
-bleach==5.0.0
+bleach==5.0.1
     # via readme-renderer
-certifi==2021.10.8
+certifi==2022.6.15
     # via requests
-charset-normalizer==2.0.12
+charset-normalizer==2.1.0
     # via requests
 click==8.1.3
     # via
@@ -29,19 +29,19 @@ code-annotations==1.3.0
     # via edx-lint
 commonmark==0.9.1
     # via rich
-coverage[toml]==6.3.3
+coverage[toml]==6.4.3
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-dill==0.3.4
+dill==0.3.5.1
     # via pylint
-docutils==0.18.1
+docutils==0.19
     # via readme-renderer
-edx-lint==5.2.2
+edx-lint==5.2.4
     # via -r requirements/quality.in
 idna==3.3
     # via requests
-importlib-metadata==4.11.3
+importlib-metadata==4.12.0
     # via
     #   keyring
     #   twine
@@ -55,7 +55,7 @@ isort==5.10.1
     #   pylint
 jinja2==3.1.2
     # via code-annotations
-keyring==23.5.0
+keyring==23.8.2
     # via twine
 lazy-object-proxy==1.7.1
     # via astroid
@@ -67,9 +67,9 @@ packaging==21.3
     # via
     #   -r requirements/test.txt
     #   pytest
-pbr==5.9.0
+pbr==5.10.0
     # via stevedore
-pkginfo==1.8.2
+pkginfo==1.8.3
     # via twine
 platformdirs==2.5.2
     # via pylint
@@ -81,7 +81,7 @@ py==1.11.0
     # via
     #   -r requirements/test.txt
     #   pytest
-pycodestyle==2.8.0
+pycodestyle==2.9.1
     # via -r requirements/quality.in
 pydocstyle==6.1.1
     # via -r requirements/quality.in
@@ -89,7 +89,7 @@ pygments==2.12.0
     # via
     #   readme-renderer
     #   rich
-pylint==2.13.9
+pylint==2.14.5
     # via
     #   -r requirements/quality.in
     #   edx-lint
@@ -118,9 +118,9 @@ python-slugify==6.1.2
     # via code-annotations
 pyyaml==6.0
     # via code-annotations
-readme-renderer==35.0
+readme-renderer==36.0
     # via twine
-requests==2.27.1
+requests==2.28.1
     # via
     #   requests-toolbelt
     #   twine
@@ -128,7 +128,7 @@ requests-toolbelt==0.9.1
     # via twine
 rfc3986==2.0.0
     # via twine
-rich==12.4.1
+rich==12.5.1
     # via twine
 six==1.16.0
     # via
@@ -137,7 +137,7 @@ six==1.16.0
     #   edx-lint
 snowballstemmer==2.2.0
     # via pydocstyle
-stevedore==3.5.0
+stevedore==4.0.0
     # via code-annotations
 text-unidecode==1.3
     # via python-slugify
@@ -147,14 +147,16 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-twine==4.0.0
+tomlkit==0.11.3
+    # via pylint
+twine==4.0.1
     # via -r requirements/quality.in
-typing-extensions==4.2.0
+typing-extensions==4.3.0
     # via
     #   astroid
     #   pylint
     #   rich
-urllib3==1.26.9
+urllib3==1.26.11
     # via
     #   requests
     #   twine
@@ -162,7 +164,7 @@ webencodings==0.5.1
     # via bleach
 wrapt==1.14.1
     # via astroid
-zipp==3.8.0
+zipp==3.8.1
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,9 +4,9 @@
 #
 #    make upgrade
 #
-attrs==21.4.0
+attrs==22.1.0
     # via pytest
-coverage[toml]==6.3.3
+coverage[toml]==6.4.3
     # via pytest-cov
 iniconfig==1.1.1
     # via pytest


### PR DESCRIPTION
Updated the upgrade target script to check the compatibility of upgraded pip and pip-tools versions.
For reference, look at this https://github.com/openedx/edx-repo-health/pull/271 for new check added in edx-repo-health.