### PR TITLE
fix: Output coverage xml correctly.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,4 @@
 [run]
-data_file = coverage.xml
 source = loncapa, verifiers, eia
 branch = true
 relative_files = True

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ deps =
 	-r requirements/test.txt
 commands =
 	coverage run -m pytest
+	coverage xml
 
 [testenv:quality]
 deps =


### PR DESCRIPTION
The data_file does not implicitly determine the output format. It's
always a SQLite database.  I changed the name back so that it wouldn't
be confusing and then updated tox.ini to generate the XML after the
tests had finish running.
