### PR TITLE
chore: add catalog-info.yaml 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,8 @@ jobs:
 
       - name: Run coverage
         if: matrix.python-version == '3.8' && matrix.toxenv == 'py38'
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           flags: unittests
           fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,17 @@
 codejail-includes
-=============================
+=================
 
 |pypi-badge| |license-badge|
 
-CodeJail manages execution of untrusted code in secure sandboxes. It is designed primarily for Python execution,
-but can be used for other languages as well.
+
+A set of utility modules available in secure sandboxes for course authors to
+use.
+
+``codejail-includes`` is the result of extracting utility modules installed
+into the codejail sandbox environment directly from edx-platform into it's
+own separate package.
+
+More in-depth context can be found in `[BOM-2579] Dissolve Sub-Projects in edx-platform <https://openedx.atlassian.net/browse/BOM-2579>`_
 
 Documentation
 -------------

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,16 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: codejail-includes
+  description: A set of utility modules available in the sandbox environment for course authors to use.
+  annotations:
+    openedx.org/arch-interest-groups: moisesgsalas
+  links:
+    - url: https://github.com/openedx/codejail-includes
+      title: Source Code
+      icon: Code
+spec:
+  owner: user:moisesgsalas
+  type: library
+  lifecycle: production
+  subcomponentOf: codejail

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -5,10 +5,6 @@ metadata:
   description: A set of utility modules available in the sandbox environment for course authors to use.
   annotations:
     openedx.org/arch-interest-groups: moisesgsalas
-  links:
-    - url: https://github.com/openedx/codejail-includes
-      title: Source Code
-      icon: Code
 spec:
   owner: user:moisesgsalas
   type: library


### PR DESCRIPTION
**Description**:

Add the missing `catalog-info.yaml` metadata file so the repository can be indexed into the Open edX Backstage catalog.

I also added a very brief description to the Readme. 